### PR TITLE
Added initializeWithUrl() to YoutubePlayerView

### DIFF
--- a/ytplayer/src/main/java/com/jaedongchicken/ytplayer/YoutubePlayerView.java
+++ b/ytplayer/src/main/java/com/jaedongchicken/ytplayer/YoutubePlayerView.java
@@ -81,6 +81,13 @@ public class YoutubePlayerView extends WebView {
         }
         initialize(videoId, youTubeListener);
     }
+    public void initializeWithUrl(String videoUrl, YTParams params, YouTubeListener youTubeListener) {
+        if(params != null) {
+            this.params = params;
+        }
+        String videoId = videoUrl.substring(videoUrl.indexOf('=')+1);
+        initialize(videoId, youTubeListener);
+    }
 
     public void setWhiteBackgroundColor() {
         backgroundColor = "#ffffff";


### PR DESCRIPTION
Allows developer to show YouTube video with full URL passed in (instead of having to parse out the video's ID)
